### PR TITLE
Add proper nav item template tag

### DIFF
--- a/kolibri/core/assets/src/core-base.vue
+++ b/kolibri/core/assets/src/core-base.vue
@@ -1,5 +1,15 @@
 <template>
-  <kolibri-nav></kolibri-nav>
+
+  <header>
+    <kolibri-nav></kolibri-nav>
+  </header>
+  <main>
+    <slot></slot>
+  </main>
+  <footer>
+    Call a podiatrist – I'm in a footer!
+  </footer>
+
 </template>
 
 <script>

--- a/kolibri/core/assets/src/core-base.vue
+++ b/kolibri/core/assets/src/core-base.vue
@@ -13,13 +13,9 @@
 </template>
 
 <script>
-const Vue = require('vue');
-import navOptions from './navigation.vue.html';
-const VueNav = Vue.extend(navOptions);
-
 export default {
   components: {
-    'kolibri-nav': VueNav,
+    'kolibri-nav': require('./navigation.vue'),
   },
 };
 </script>

--- a/kolibri/core/hooks.py
+++ b/kolibri/core/hooks.py
@@ -17,12 +17,32 @@ import logging
 
 from kolibri.plugins.hooks import KolibriHook
 
-
 logger = logging.getLogger(__name__)
 
 
 class NavigationHook(KolibriHook):
 
+    # : A string label for the menu item
+    label = "Untitled"
+
+    # : A string or lazy proxy for the url
+    url = "/"
+
+    def get_menu(self):
+        menu = {}
+        for hook in self.registered_hooks:
+            menu[hook.label] = self.url
+        return menu
+
+    class Meta:
+
+        abstract = True
+
+
+class UserNavigationHook(KolibriHook):
+    """
+    A hook for adding navigation items to the user menu.
+    """
     # : A string label for the menu item
     label = "Untitled"
 

--- a/kolibri/core/templates/kolibri/base.html
+++ b/kolibri/core/templates/kolibri/base.html
@@ -1,20 +1,10 @@
 {% load i18n kolibri_tags webpack_tags js_reverse cache %}<html>
 <head>
   <title>{% block title %}{% endblock %} - {% trans "Kolibri" %}</title>
+  {% kolibri_main_navigation %}
 </head>
 
 <body>
-
-{% block main_menu %}
-<ul role="nav">
-  {% kolibri_main_navigation as nav %}
-
-  {% for item in nav %}
-  <li><a href="{{ item.url }}">{{ item.label }}</a></li>
-  {% endfor %}
-
-</ul>
-{% endblock %}
 
 <main></main>
 {% block frontend_assets %}

--- a/kolibri/core/templatetags/kolibri_tags.py
+++ b/kolibri/core/templatetags/kolibri_tags.py
@@ -8,7 +8,7 @@ import json
 
 from django import template
 from django.utils.html import mark_safe
-from kolibri.core.hooks import NavigationHook
+from kolibri.core.hooks import NavigationHook, UserNavigationHook
 
 register = template.Library()
 
@@ -26,6 +26,12 @@ def kolibri_main_navigation():
 
     for hook in NavigationHook().registered_hooks:
         init_data['nav_items'].append({
+            'text': str(hook.label),
+            'url': str(hook.url),
+        })
+
+    for hook in UserNavigationHook().registered_hooks:
+        init_data['user_nav_items'].append({
             'text': str(hook.label),
             'url': str(hook.url),
         })

--- a/kolibri/core/templatetags/kolibri_tags.py
+++ b/kolibri/core/templatetags/kolibri_tags.py
@@ -4,7 +4,10 @@ Kolibri template tags
 """
 from __future__ import absolute_import, print_function, unicode_literals
 
+import json
+
 from django import template
+from django.utils.html import mark_safe
 from kolibri.core.hooks import NavigationHook
 
 register = template.Library()
@@ -12,6 +15,22 @@ register = template.Library()
 
 @register.simple_tag()
 def kolibri_main_navigation():
+    """
+    A tag to include an initial JS-object to bootstrap data into the app.
+    :return: An html string
+    """
+    init_data = {
+        'nav_items': [],
+        'user_nav_items': [],
+    }
 
     for hook in NavigationHook().registered_hooks:
-        yield hook
+        init_data['nav_items'].append({
+            'text': str(hook.label),
+            'url': str(hook.url),
+        })
+
+    html = ("<script type='text/javascript'>"
+            "window._nav={0};"
+            "</script>".format(json.dumps(init_data)))
+    return mark_safe(html)

--- a/kolibri/plugins/learn/kolibri_plugin.py
+++ b/kolibri/plugins/learn/kolibri_plugin.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
+from django.utils.translation import ugettext_lazy as _
+from kolibri.core.hooks import NavigationHook
 from kolibri.core.webpack import hooks as webpack_hooks
 from kolibri.plugins.base import KolibriPluginBase
 
@@ -22,3 +24,8 @@ class LearnAsset(webpack_hooks.WebpackBundleHook):
 
 class LearnInclusionHook(hooks.LearnSyncHook):
     bundle_class = LearnAsset
+
+
+class ManagementNavItem(NavigationHook):
+    label = _("Learn!")
+    url = '#'

--- a/kolibri/plugins/management/assets/src/main.vue
+++ b/kolibri/plugins/management/assets/src/main.vue
@@ -1,22 +1,23 @@
 <template>
-  <div>
-    <drop-down v-ref:classroom-selector :list="classrooms" :selected.sync="selectedClassroom"></drop-down>
-    <button v-on:click="addClassroom({name: 'foo'})">Create</button>
-    <button>Delete</button>
-  </div>
-  <div>
-    <drop-down v-ref:learner-group-selector :list="[]" :initial-selection=""></drop-down>
-    <button>Create</button>
-    <button>Delete</button>
-  </div>
-  <learner-roster v-ref:learner-roster :learners="filteredLearners"></learner-roster>
+
+  <core-base>
+    <div>
+      <drop-down v-ref:classroom-selector :list="classrooms" :selected.sync="selectedClassroom"></drop-down>
+      <button v-on:click="addClassroom({name: 'foo'})">Create</button>
+      <button>Delete</button>
+    </div>
+    <div>
+      <drop-down v-ref:learner-group-selector :list="[]" :initial-selection=""></drop-down>
+      <button>Create</button>
+      <button>Delete</button>
+    </div>
+    <learner-roster v-ref:learner-roster :learners="filteredLearners"></learner-roster>
+  </core-base>
+
 </template>
 
 
 <script>
-const learnerRoster = require('./learner-roster.vue');
-const dropDown = require('./drop-down.vue');
-
 const actions = require('./vuex/actions.js');
 const addClassroom = actions.addClassroom;
 const setSelectedClassroomId = actions.setSelectedClassroomId;
@@ -30,8 +31,9 @@ const constants = store.constants;
 
 export default {
   components: {
-    'learner-roster': learnerRoster,
-    'drop-down': dropDown,
+    'core-base': require('core-base'),
+    'learner-roster': require('./learner-roster.vue'),
+    'drop-down': require('./drop-down.vue'),
   },
   computed: {
     classrooms() {

--- a/kolibri/plugins/management/kolibri_plugin.py
+++ b/kolibri/plugins/management/kolibri_plugin.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
+from django.utils.translation import ugettext_lazy as _
+from kolibri.core.hooks import UserNavigationHook
 from kolibri.core.webpack import hooks as webpack_hooks
 from kolibri.plugins.base import KolibriPluginBase
 
@@ -22,3 +24,8 @@ class ManagementAsset(webpack_hooks.WebpackBundleHook):
 
 class ManagementInclusionHook(hooks.ManagementSyncHook):
     bundle_class = ManagementAsset
+
+
+class ManagementNavItem(UserNavigationHook):
+    label = _("Management!")
+    url = '#'


### PR DESCRIPTION
## Summary

I added a template tag that makes use of the new hook system to inject nav item data into the base template, just the way we did it before. In particular, look at the last two commits for examples of how to add new nav items and user nav items. I also fixed up the management vue template and core-base template to use this stuff. Take a peek through the changes and make sure you get the gist of it.

For now since you're working on the front-end it's not super important to understand everything about the hooks -- just see how to add new nav menu items.

After you've reviewed this and we've merged it, open a new PR targeting `learningequality/master`. The next steps are to continue working on the navigation vue.
