### PR TITLE
Corrected aria states &properties

### DIFF
--- a/kolibri/plugins/management/assets/src/vue/modal/index.vue
+++ b/kolibri/plugins/management/assets/src/vue/modal/index.vue
@@ -23,8 +23,8 @@
       <!-- Not mandatory, but if available, names the modal according aria-labels -->
       <h1 v-show="!invisibleTitle" class="title" id="modal-title">
         <!-- Accessible error reporting per @radina -->
-        <span v-if="error" class="accessible-error-indicator" aria-hidden=true>
-          Error:
+        <span v-if="error" class="visuallyhidden">
+          Error in:
         </span>
           {{title}}
       </h1>
@@ -165,10 +165,6 @@
 
   .title
     text-align: center
-
-  // not necessary for sighted users
-  .accessible-error-indicator
-    display: none
 
   // Animation Specs
   .modal-enter, .modal-leave

--- a/kolibri/plugins/management/assets/src/vue/user-page/user-create-modal.vue
+++ b/kolibri/plugins/management/assets/src/vue/user-page/user-create-modal.vue
@@ -37,14 +37,14 @@
 
       <!-- Button Options at footer of modal -->
       <section class="footer">
-        <p class="error-message" v-if="errorMessage">{{errorMessage}}</p>
+        <p class="error-message" v-if="errorMessage" aria-live="polite">{{errorMessage}}</p>
         <button class="create-btn" type="button" @click="createNewUser">Create Account</button>
       </section>
     </div>
   </modal>
 
   <icon-button @click="open" class="add-user-button" text="Add New" :primary="false">
-    <svg class="add-user" src="../icons/add_new_user.svg"></svg>
+    <svg class="add-user" src="../icons/add_new_user.svg" role="presentation"></svg>
   </icon-button>
 
 </template>


### PR DESCRIPTION
## Summary

No need to define a new class here, `visuallyhidden` is global... :wink: 

Avoid `display: none` and try to find alternatives even to `aria-hidden="true"` too, as its browser support is inconsistent. Good but long reference is here:

https://www.paciellogroup.com/blog/2012/05/html5-accessibility-chops-hidden-and-aria-hidden/

Granted I could have made inline comments on your PR, but I wanted to try submitting one on a non-master branch! :blush:  
